### PR TITLE
chore: streamline PostCSS plugins

### DIFF
--- a/emp-hub/postcss.config.js
+++ b/emp-hub/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
     plugins: {
         '@tailwindcss/postcss': {},
-        autoprefixer: {},
     },
 }


### PR DESCRIPTION
## Summary
- prevent autoprefixer from running twice by relying on `@tailwindcss/postcss`

## Testing
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_b_6892858e29bc832194b46fd908e82561