### PR TITLE
feat: update dashboard design for dark mode

### DIFF
--- a/emp-hub/src/Dashboard/Dashboard.jsx
+++ b/emp-hub/src/Dashboard/Dashboard.jsx
@@ -9,16 +9,18 @@ const links = [
 
 export default function Dashboard() {
     return (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 p-6">
-            {links.map((link) => (
-                <Link
-                    to={link.to}
-                    key={link.to}
-                    className="bg-white p-6 rounded-xl shadow hover:shadow-lg transition duration-300"
-                >
-                    <h2 className="text-xl font-semibold text-gray-800">{link.label}</h2>
-                </Link>
-            ))}
+        <div className="min-h-screen w-full flex items-center justify-center bg-gradient-to-br from-blue-200 to-indigo-200 dark:from-slate-900 dark:to-slate-800 transition-colors duration-700">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 w-full max-w-5xl p-6">
+                {links.map((link) => (
+                    <Link
+                        to={link.to}
+                        key={link.to}
+                        className="flex items-center justify-center bg-white/90 dark:bg-slate-900/90 shadow-2xl rounded-3xl py-10 px-8 text-xl font-semibold text-blue-800 dark:text-blue-200 hover:scale-105 hover:bg-blue-200/60 dark:hover:bg-slate-800/80 transition-all duration-300"
+                    >
+                        <h2 className="text-center">{link.label}</h2>
+                    </Link>
+                ))}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add gradient background wrapper with dark colors to Dashboard
- improve cards with dark text, hover effects, and spacing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689285978f1c83219798c8a7cc34ec79